### PR TITLE
decl: Error out if 'restrict' is used in non-pointer, non-array types

### DIFF
--- a/decl.c
+++ b/decl.c
@@ -466,6 +466,9 @@ declspecs(struct scope *s, enum storageclass *sc, enum funcspec *fs, int *align)
 			error(&tok.loc, "multiple types in declaration specifiers");
 	}
 done:
+	if ((tq & QUALRESTRICT) && (!t || (t->kind != TYPEPOINTER && t->kind != TYPEARRAY)))
+		error(&tok.loc, "'restrict' is only allowed in pointer and array types");
+
 	switch ((int)ts) {
 	case SPECNONE:                                            break;
 	case SPECCHAR:                          t = &typechar;    break;


### PR DESCRIPTION
Hi,

With this fix, code such as:
```c
restrict int x;
```
is now rejected.

Cheers!