### PR TITLE
expr: 8 is not an octal digit

### DIFF
--- a/expr.c
+++ b/expr.c
@@ -421,7 +421,7 @@ inttype(unsigned long long val, bool decimal, char *end)
 static int
 isodigit(int c)
 {
-	return '0' <= c && c <= '8';
+	return '0' <= c && c <= '7';
 }
 
 static size_t


### PR DESCRIPTION
8 was incorrectly classified as octal digit in `\000` octal escape sequences. `strlen("\078")` should return value 2 instead of 1.

(Original K&R1 C silently allowed 8 and 9 in octal literals, but that was fixed already in C89 standard.)